### PR TITLE
[UI] add new color scheme for the application

### DIFF
--- a/CyberCatMain/constants/Colors.ts
+++ b/CyberCatMain/constants/Colors.ts
@@ -23,4 +23,12 @@ export const Colors = {
     tabIconDefault: '#9BA1A6',
     tabIconSelected: tintColorDark,
   },
+  brown: {
+    text: 'rgb(134, 47, 16)',
+    background: 'rgb(237, 102, 102)',
+    tint: tintColorDark,
+    icon: 'rgb(93, 30, 7)',
+    tabIconDefault: 'rgb(93, 30, 7)', 
+    tabIconSelected: tintColorDark,
+  },
 };


### PR DESCRIPTION
This color scheme is used to declare the main color theme that will be used in all pages of the application. The background will all be in light brown color while the text color is set in dark brown. Given that there could be alternative color schemes in the future, it is important to anchor our ui settings in the early stage of the development.

**_For REVIEWER, TODO:_** review the style and give additional suggestions on the color settings if there are.
**_For All, TODO (after approved):_** rebase your dev branch to allow the new color scheme to be included and follow the color scheme settings by referring to the constant