### PR TITLE
[Extension]Update Achievement UI and Implement basic achievement trigger mechanism

### DIFF
--- a/CyberCatMain/app/account/userInfo.js
+++ b/CyberCatMain/app/account/userInfo.js
@@ -23,12 +23,14 @@ const navigateToLogin = () => {useRouter().push("/")};
  It returns nothing and since the process is async, another set function is required for a temporary variable in the 
  app page(with useState) so that the page can be re-rendered after the information is retrieved 
 */
-export function getUserInfo(attribute, setFunction){
- 
- onAuthStateChanged(auth, (user) => {
+export function getUserInfo(attribute, setFunction = () => {}){
+
+/* Legacy implementation. Left for reference
+
+   onAuthStateChanged(auth, (user) => {
   if (user) {
-    // User is signed in, see docs for a list of available properties
-    // https://firebase.google.com/docs/reference/js/auth.user
+    User is signed in, see docs for a list of available properties
+    https://firebase.google.com/docs/reference/js/auth.user
     
     getDoc(doc(collectionRef, user.uid)).then( (doc) => {
       if (doc.exists()) {
@@ -42,12 +44,25 @@ export function getUserInfo(attribute, setFunction){
         console.log("Error getting document:", error);
         return error;
   });
-  
   } else {
     // User is signed out
     unsubscribe();
   }
 });
+*/
+    return getDoc(doc(collectionRef, currentUser)).then( (doc) => {
+      if (doc.exists()) {
+        const targetData = doc.data()[attribute];
+        setFunction(targetData);
+        return targetData;
+      }else {
+        // doc.data() will be undefined in this case
+        console.log("No such document!");
+      }
+    }).catch((error) => {
+        console.log("Error getting document:", error);
+        return error;
+  });
   
 }
 
@@ -64,6 +79,7 @@ export function signInUser(email, password, router){
          .then((userCredential) => {
             // Signed in 
             displayToast("Login Success");
+            currentUser = userCredential.user.uid;
             navigateToMain(router);
          }).catch(displayError("Meow? Wrong password?"));
     
@@ -72,8 +88,8 @@ export function signInUser(email, password, router){
 /* This function signs out the current user in the device and returns nothing
  */
 export function signOutUser(){
-  signOut(auth).then(() => {console.log("signed out successfully")})
-               .catch(console.log);
+  signOut(auth).then(() => {console.log("signed out successfully"); 
+                            currentUser = "0000";}).catch(console.log);
 }
 
 /* This function takes in the user information in the register page and update the 

--- a/CyberCatMain/app/mainPages/Achievement/achievement.js
+++ b/CyberCatMain/app/mainPages/Achievement/achievement.js
@@ -1,21 +1,11 @@
 
 import { achievementList } from '../../../constants/achievementList.js';
+import { StyleSheet, Dimensions ,View ,Text} from 'react-native';
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
 
-// export const updateAchievementStatus = async () => {
-//  const updatedList = [];
-//  return Promise.resolve(
-//     achievementList.forEach((achievement) => {
-//         achievement.criteria().then((condition)=>{
-//             return condition;
-//         }).then((condition) => { 
-//          updatedList.push({
-//         ...achievement,
-//         completed: condition
-//       });
-//     });
-//     })).then(() => updatedList);
-  
-// }
+const LockedIcon = () => <FontAwesome5 name="question" size={30} color="black" />;
+const UnlockedIcon = () => <FontAwesome5 name="star" size={30} color="rgb(245, 237, 14)" />;
+const screenWidth = Dimensions.get('window').width;
 
 export async function updateAchievementStatus() {
   // Kick off one promise per achievement:
@@ -39,3 +29,52 @@ export const processList = (newlist, filterFunc, sortFunc) => {
     return newlist.filter(item => !(item.hidden && !item.completed) && filterFunc).sort(sortFunc);
     
  }
+ export const countAttainedAchievements = (achList) => achList.filter(item => item.completed).length;
+
+ export const AchievementView = ({item}) => {
+    return  (<View style={[styles.card, item.completed ? styles.cardComplete : styles.cardIncomplete]}>
+                            {item.completed ?
+                                (<UnlockedIcon/>) : (<LockedIcon/>)
+                            }
+                            <View style={styles.box}>
+                                <Text style={styles.title}>{item.title}</Text>
+                                <Text style={styles.description}>{item.description}</Text>
+                            </View>
+                        </View>);
+ }
+
+ const styles = StyleSheet.create({
+
+     card: {
+         flexDirection: 'row',
+         padding: 30,
+         width: screenWidth,
+         marginBottom: 10,
+         marginTop: 10,
+         borderRadius: 10,
+         marginHorizontal: 'auto',
+     },
+     cardComplete: {
+         backgroundColor: 'pink',
+         borderWidth: 3,
+         borderColor: 'rgb(245, 237, 14)'
+     },
+     cardIncomplete: {
+         backgroundColor: 'grey',
+     },
+     box: {
+         flex: 1,
+         marginLeft: 20,
+         flexDirection: 'column',
+     },
+     title: {
+         color: 'white',
+         fontSize: 20,
+         fontWeight: 'bold'
+     },
+     description: {
+         color: 'black',
+         fontSize: 15,
+     },
+ }
+ );

--- a/CyberCatMain/app/mainPages/Achievement/achievement.js
+++ b/CyberCatMain/app/mainPages/Achievement/achievement.js
@@ -1,0 +1,41 @@
+
+import { achievementList } from '../../../constants/achievementList.js';
+
+// export const updateAchievementStatus = async () => {
+//  const updatedList = [];
+//  return Promise.resolve(
+//     achievementList.forEach((achievement) => {
+//         achievement.criteria().then((condition)=>{
+//             return condition;
+//         }).then((condition) => { 
+//          updatedList.push({
+//         ...achievement,
+//         completed: condition
+//       });
+//     });
+//     })).then(() => updatedList);
+  
+// }
+
+export async function updateAchievementStatus() {
+  // Kick off one promise per achievement:
+  const checks = achievementList.map(async achievement => {
+    const condition = await achievement.criteria();
+    return { ...achievement, completed: condition };
+  });
+
+  // Wait here until *all* those criteria() calls have finished:
+  const updatedList = await Promise.all(checks);
+
+  return updatedList;  // now a proper [ {…}, {…}, … ] array
+}
+
+
+export const processList = (newlist, filterFunc, sortFunc) => {   
+    console.log("1234");
+    console.log(newlist);
+ 
+    // need further debugging for the filter function
+    return newlist.filter(item => !(item.hidden && !item.completed) && filterFunc).sort(sortFunc);
+    
+ }

--- a/CyberCatMain/app/mainPages/Achievement/achievement.js
+++ b/CyberCatMain/app/mainPages/Achievement/achievement.js
@@ -1,10 +1,19 @@
 
 import { achievementList } from '../../../constants/achievementList.js';
-import { StyleSheet, Dimensions ,View ,Text} from 'react-native';
+import { StyleSheet, Dimensions ,View ,Text, TouchableOpacity} from 'react-native';
 import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import AntDesign from '@expo/vector-icons/AntDesign';
+import { useState } from 'react';
+import { IconList } from '../../../constants/IconList.js';
 
-const LockedIcon = () => <FontAwesome5 name="question" size={30} color="black" />;
-const UnlockedIcon = () => <FontAwesome5 name="star" size={30} color="rgb(245, 237, 14)" />;
+
+const LockedIcon = IconList.locked; 
+const UnlockedIcon =  IconList.unlocked;
+const CollapseIcon = IconList.collapse;
+
+
+
 const screenWidth = Dimensions.get('window').width;
 
 export async function updateAchievementStatus() {
@@ -32,14 +41,18 @@ export const processList = (newlist, filterFunc, sortFunc) => {
  export const countAttainedAchievements = (achList) => achList.filter(item => item.completed).length;
 
  export const AchievementView = ({item}) => {
+    let [collasped, setCollapsed] = useState(true);
     return  (<View style={[styles.card, item.completed ? styles.cardComplete : styles.cardIncomplete]}>
                             {item.completed ?
                                 (<UnlockedIcon/>) : (<LockedIcon/>)
                             }
                             <View style={styles.box}>
                                 <Text style={styles.title}>{item.title}</Text>
-                                <Text style={styles.description}>{item.description}</Text>
+                               {collasped && <Text style={styles.description}>{item.description}</Text> } 
                             </View>
+                            <TouchableOpacity onPress={() => setCollapsed(!collasped)}>
+                                <CollapseIcon />
+                            </TouchableOpacity>
                         </View>);
  }
 

--- a/CyberCatMain/app/mainPages/Achievement/screen.jsx
+++ b/CyberCatMain/app/mainPages/Achievement/screen.jsx
@@ -1,15 +1,33 @@
 import { View, Text, Button, StyleSheet, FlatList, Dimensions } from 'react-native'
 import React, { useEffect, useRef, useState } from 'react'
 import { achievementList } from '../../../constants/achievementList'
+import {StatusDisplay} from '@/components/StatusDisplay';
 import { updateAchievementStatus, processList, AchievementView, countAttainedAchievements } from './achievement'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { IconList } from '../../../constants/IconList';
+const screenWidth = Dimensions.get('window').width;
 
-const screenWidth = Dimensions.get('window').width
+
+
+
 
 export default function screen() {
-
+    
     let [orderedAch, setOrderedAch] = useState([]);
-    console.log("rendered");
+
+    const AchievementCountComp = () => (
+        <View style = {{flexDirection: 'row', marginHorizontal:'auto', justifyContent: 'space-around', marginBottom: 20}}>
+            <StatusDisplay attribute = {''} 
+                           text = {'   '} 
+                           value = {countAttainedAchievements(orderedAch)} 
+                           Child = {IconList.unlocked} />
+            <StatusDisplay attribute = {''} 
+                           text = {'   '} 
+                           value = {orderedAch.length - countAttainedAchievements(orderedAch)} 
+                           Child = {IconList.locked} />
+        </View>);
+
+  
     useEffect( () => {
         console.log("called");
         updateAchievementStatus()
@@ -20,11 +38,10 @@ export default function screen() {
          });
          },[]);
   
-    
     return (
         <SafeAreaView style={styles.container}>
             <Text style={styles.text}>Achievements</Text>
-            <Text> Total attained achievements: {countAttainedAchievements(orderedAch)}</Text>
+            <AchievementCountComp />
             <FlatList
                 data={orderedAch}
                 keyExtractor={(item) => item.id}
@@ -32,7 +49,6 @@ export default function screen() {
                     <AchievementView item={item} />
                 )}
             />
-            <Text>End of Achievement List</Text>
         </SafeAreaView>
     );
 }

--- a/CyberCatMain/app/mainPages/Achievement/screen.jsx
+++ b/CyberCatMain/app/mainPages/Achievement/screen.jsx
@@ -1,32 +1,36 @@
 import { View, Text, Button, StyleSheet, FlatList, Dimensions } from 'react-native'
-import React, { useRef } from 'react'
-import {achievementList} from '@/constants/achievementList.js'
+import React, { useEffect, useRef, useState } from 'react'
+import { achievementList } from '../../../constants/achievementList'
+import { updateAchievementStatus, processList } from './achievement'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 const screenWidth = Dimensions.get('window').width
 
-export function updateAchievementStatus() {
-    return achievementList.map(achievement => ({
-        ...achievement,
-        complete: achievement.criteria
-    }))
-}
-
 export default function screen() {
-    const updatedList = updateAchievementStatus();
-    const visibleList = updatedList.filter(item => !(item.hidden & !item.complete))
-    const completeAch = visibleList.filter(item => item.complete);
-    const incompleteAch = visibleList.filter(item => !item.complete);
-    const orderedAch = [...completeAch, ...incompleteAch];
+
+    
+    let [orderedAch, setOrderedAch] = useState([]);
+    console.log("rendered");
+    useEffect( () => {
+        console.log("called");
+        updateAchievementStatus()
+       .then((newList) => { 
+        const processed = processList(newList, (item) => true, (a,b) => (b.completed - a.completed));
+        setOrderedAch(processed);
+        console.log(processed);
+         });
+         },[]);
+  
 
     return (
-        <View style={styles.container}>
+        <SafeAreaView style={styles.container}>
             <Text style={styles.text}>Achievements</Text>
             <FlatList
                 data={orderedAch}
                 keyExtractor={(item) => item.id}
                 renderItem={({ item }) => (
-                    <View style={[styles.card, item.complete ? styles.cardComplete : styles.cardIncomplete]}>
-                        {item.complete ?
+                    <View style={[styles.card, item.completed ? styles.cardComplete : styles.cardIncomplete]}>
+                        {item.completed ?
                             (<Text>icon</Text>) : (<Text>question</Text>)
                         }
                         <View style={styles.box}>
@@ -37,7 +41,7 @@ export default function screen() {
                 )}
             />
             <Text>navigationBar</Text>
-        </View>
+        </SafeAreaView>
     );
 }
 

--- a/CyberCatMain/app/mainPages/Achievement/screen.jsx
+++ b/CyberCatMain/app/mainPages/Achievement/screen.jsx
@@ -1,14 +1,13 @@
 import { View, Text, Button, StyleSheet, FlatList, Dimensions } from 'react-native'
 import React, { useEffect, useRef, useState } from 'react'
 import { achievementList } from '../../../constants/achievementList'
-import { updateAchievementStatus, processList } from './achievement'
+import { updateAchievementStatus, processList, AchievementView, countAttainedAchievements } from './achievement'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 const screenWidth = Dimensions.get('window').width
 
 export default function screen() {
 
-    
     let [orderedAch, setOrderedAch] = useState([]);
     console.log("rendered");
     useEffect( () => {
@@ -21,26 +20,19 @@ export default function screen() {
          });
          },[]);
   
-
+    
     return (
         <SafeAreaView style={styles.container}>
             <Text style={styles.text}>Achievements</Text>
+            <Text> Total attained achievements: {countAttainedAchievements(orderedAch)}</Text>
             <FlatList
                 data={orderedAch}
                 keyExtractor={(item) => item.id}
                 renderItem={({ item }) => (
-                    <View style={[styles.card, item.completed ? styles.cardComplete : styles.cardIncomplete]}>
-                        {item.completed ?
-                            (<Text>icon</Text>) : (<Text>question</Text>)
-                        }
-                        <View style={styles.box}>
-                            <Text style={styles.title}>{item.title}</Text>
-                            <Text style={styles.description}>{item.description}</Text>
-                        </View>
-                    </View>
+                    <AchievementView item={item} />
                 )}
             />
-            <Text>navigationBar</Text>
+            <Text>End of Achievement List</Text>
         </SafeAreaView>
     );
 }
@@ -88,6 +80,6 @@ const styles = StyleSheet.create({
         fontSize: 15,
     },
 }
-)
+);
 
 

--- a/CyberCatMain/components/StatusDisplay.tsx
+++ b/CyberCatMain/components/StatusDisplay.tsx
@@ -8,21 +8,28 @@ import { useState } from 'react';
                                   Child, 
                                   mapFunction = (x) => (x), 
                                   viewStyle = {},
-                                  fontSize = 0}: 
+                                  fontSize = 0,
+                                  value = -1}: 
                                  {attribute: string, 
                                   Child: any
                                   viewStyle: any
                                   text: string
                                   fontSize: number
                                   mapFunction: (arg0: any) => string
+                                  value: number
                                 }) => {
-    const [userVar, setUserVar] = useState("");
-    getUserInfo(attribute, setUserVar);
+    const [userVar, setUserVar] = useState(value + "");
+    // value is only positive number
+    if(value == -1) getUserInfo(attribute, setUserVar);
     return  (
       <View style = {[accountStyles.StatusView, viewStyle]}>
         {Child && <Child/>}
-        {text != "NONE" && <Text style = {[accountStyles.infoText, {paddingTop: 4}, fontSize ? {fontSize: fontSize} : {}]}> {text} </Text>}
-        <Text style = {[accountStyles.infoText, {paddingTop: 3}, fontSize ? {fontSize: fontSize} : {}]}>{mapFunction(userVar)}</Text>
+        {text != "NONE" && <Text style = {[accountStyles.infoText, 
+                                          {paddingTop: 4},  
+                                           fontSize ? {fontSize: fontSize} : {}]}> {text} </Text>}
+        <Text style = {[accountStyles.infoText, 
+                       {paddingTop: 3},   
+                        fontSize ? {fontSize: fontSize} : {}]}>{mapFunction(userVar)}</Text>
       </View>
     );
 

--- a/CyberCatMain/constants/AchievementStyles.ts
+++ b/CyberCatMain/constants/AchievementStyles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from "react-native";
+
+export const AchievementStyles = StyleSheet.create(
+    {
+        
+    }
+);

--- a/CyberCatMain/constants/IconList.js
+++ b/CyberCatMain/constants/IconList.js
@@ -1,0 +1,13 @@
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import AntDesign from '@expo/vector-icons/AntDesign';  
+  
+
+export const IconList = {
+   time : () => (<Ionicons name="timer-sharp" size={40} color="black" />),
+   coin : () => (<AntDesign name="pay-circle1" size={24} color="black" />),
+   user : () => (<AntDesign name="user" size={24} color="black" />),
+   locked : () => (<FontAwesome5 name="question" size={30} color="rgb(109, 109, 109)" />),
+   unlocked : () => (<AntDesign name="star" size={30} color="rgb(232, 244, 11)" />),
+   collapse : () => (<Ionicons name="chevron-expand" size={24} color="rgb(255, 255, 255)" />),
+}

--- a/CyberCatMain/constants/achievementList.js
+++ b/CyberCatMain/constants/achievementList.js
@@ -1,20 +1,33 @@
+
+import {getUserInfo} from '../app/account/userInfo.js'
+// This function returns a promise
+const StatusCheck = (attribute) => (predicate) => async () => {
+   return getUserInfo(attribute).then((info) => predicate(info));
+} 
+
 export const achievementList = [
     {
-        id: '0',
+        id: 0,
         title: 'one cat a day',
         description: 'one cat a day, keeps the doctor away!',
-        criteria: (userStats) => userStats.focusSessions >= 1,
+        hidden: false,
+        criteria: StatusCheck("focusSessionCount")(x => x >= 1),
+      
     },
     {
-        id: '1',
+        id: 1,
         title: 'kitty patty',
         description: 'pat the kitty and feel better',
-        criteria: (userStats) => userStats.focusSessions >= 5,
+        hidden: false,
+        criteria: StatusCheck("focusSessionCount")(x => x >= 5),
+     
     },
     {
-        id: '2',
+        id: 2,
         title: 'paw-sitive progress',
+        hidden: false,
         description: 'completed at least one focus session for 3 consecutive days',
-        criteria: (userStats) => userStats.focusSessions >= 10,
+        criteria:  StatusCheck("focusSessionCount")(x => x >= 10),
+     
     },
 ]

--- a/CyberCatMain/constants/achievementList.js
+++ b/CyberCatMain/constants/achievementList.js
@@ -8,26 +8,114 @@ const StatusCheck = (attribute) => (predicate) => async () => {
 export const achievementList = [
     {
         id: 0,
-        title: 'one cat a day',
-        description: 'one cat a day, keeps the doctor away!',
+        title: 'A small step',
+        description: 'Complete a total of 1 focus session',
         hidden: false,
         criteria: StatusCheck("focusSessionCount")(x => x >= 1),
       
     },
     {
         id: 1,
-        title: 'kitty patty',
-        description: 'pat the kitty and feel better',
+        title: 'High Five',
+        description: 'Complete a total of 5 focus session',
         hidden: false,
         criteria: StatusCheck("focusSessionCount")(x => x >= 5),
      
     },
     {
         id: 2,
-        title: 'paw-sitive progress',
+        title: 'Paw-sitive progress',
         hidden: false,
-        description: 'completed at least one focus session for 3 consecutive days',
+        description: 'Complete a total of 10 focus sessions',
         criteria:  StatusCheck("focusSessionCount")(x => x >= 10),
      
     },
+    {
+        id: 3,
+        title: 'Focus-lust',
+        hidden: false,
+        description: 'complete a total of 50 focus sessions',
+        criteria:  StatusCheck("focusSessionCount")(x => x >= 50),
+     
+    },
+    {
+        id: 4,
+        title: 'Joyeux de vie',
+        hidden: false,
+        description: 'complete a total of 100 focus sessions',
+        criteria:  StatusCheck("focusSessionCount")(x => x >= 100),
+     
+    },
+      {
+        id: 5,
+        title: 'Nihilism',
+        hidden: true,
+        description: 'complete a total of 250 focus sessions',
+        criteria:  StatusCheck("focusSessionCount")(x => x >= 200),
+     
+    },
+      {
+        id: 6,
+        title: 'Hour ONE',
+        hidden: false,
+        description: 'The first hour you have spent on focus sessions',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600),
+    },
+    {
+        id: 7,
+        title: 'It takes 3',
+        hidden: false,
+        description: 'You have spent 3 hours in total on focus',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600 * 3),
+    },
+    {
+        id: 8,
+        title: 'It takes 3',
+        hidden: false,
+        description: 'You have spent 5 hours in total on focus',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600 * 5),
+    },
+    {
+        id: 9,
+        title: 'It takes 3',
+        hidden: false,
+        description: 'You have spent 10 hours in total on focus',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600 * 10),
+    },
+    {
+        id: 10,
+        title: 'It takes 3',
+        hidden: false,
+        description: 'You have spent 20 hours in total on focus',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600 * 20),
+    },
+    {
+        id: 10,
+        title: '42',
+        hidden: false,
+        description: 'The ultimate anwser to the universe',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600 * 42),
+    },
+     {
+        id: 11,
+        title: 'Decillion encounters',
+        hidden: true,
+        description: 'Not exponential in hour but exponential in effort. Thank you for all the time',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600 * 330),
+    },
+     {
+        id: 12,
+        title: 'Outperformer',
+        hidden: false,
+        description: 'We should not be satisfied with 100 but always strive for 101. (Spent 101 hours in total)',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600 * 101),
+    },
+    {
+        id: 13,
+        title: 'Patience!',
+        hidden: true,
+        description: 'Spent the maximum possible time in a single focus session',
+        criteria:  StatusCheck("totalFocus")(x => x >= 3600),
+    },
+
 ]


### PR DESCRIPTION
The following functions will be implemented:
1. allow all achievement that checks its status through cloud firestore to be implemented in the application. (OK) Currently, the achievements are only checked when the user enters the achievement page instead of OnSnapShot to minimise database request.
2.  Improved UI, displaying the number of attained/not attained achievements and making the description collapsable (OK)
3. A few more achievements that checks focus session count and total focus time (OK)
4. A search bar that allows searching the achievements by its name. (TODO)
