### PR TITLE
[Enhancement] Update on uploading focus sessions and coins to firebase

### DIFF
--- a/CyberCatMain/constants/UserInitialInfo.js
+++ b/CyberCatMain/constants/UserInitialInfo.js
@@ -4,7 +4,7 @@ export const UserInitInfo = (username) => ( {
 
   username: username,
   listOfAchievements: [1],
-
+  focusSession: [],
   listOfCats: [
     {
         id: 0,


### PR DESCRIPTION
# Preview
This is a follow up to the timer function where more backend upload requests will be implemented so that the timer feature will be integrated more seamlessly with other features such as the cat cafe and future extensions

1. Allow coins to be obtained after each focus session ends **(Finished)**
2. Allow info about each focus session to be uploaded after the focus session ends **(Finished)**